### PR TITLE
ci: build a multi-platform container image

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,12 +38,18 @@ jobs:
         with:
           images: |
             ghcr.io/camptocamp/kwkhtmltopdf
-            
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build + Push kwkhtmltopdf
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-kwkhtmltopdf.outputs.tags }}
           labels: ${{ steps.meta-kwkhtmltopdf.outputs.labels }}


### PR DESCRIPTION
QoQa is asking us to use ARM64 nodes in their Kubernetes clusters to reduce the costs. This PR should enable building multi-platform container images to achieve this goal.